### PR TITLE
Request Leave Issue Fix

### DIFF
--- a/HR.LeaveManagement.MVC/Middleware/RequestMiddleware.cs
+++ b/HR.LeaveManagement.MVC/Middleware/RequestMiddleware.cs
@@ -42,7 +42,7 @@ namespace HR.LeaveManagement.MVC.Middleware
                         JwtSecurityTokenHandler tokenHandler = new();
                         var tokenContent = tokenHandler.ReadJwtToken(token);
                         var expiry = tokenContent.ValidTo;
-                        if (expiry < DateTime.Now)
+                        if (expiry < DateTime.UtcNow)
                         {
                             tokenIsValid = false;
                         }


### PR DESCRIPTION
The user is redirected to the login screen on click of the Request Leave menu since the RequestMiddleware invalidates the token incorrectly.